### PR TITLE
Allow configuring of the termination signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ Main features:
   failed state.
 - is about **200 loc** simple to copy and adapt to your custom needs.
 
+Configuration:
+- By default applications are killed using the `TERM` signal. This can be configured to the `INT` signal by setting the `GOUP_TERM_SIGNAL` environment variable to either `TERM` or `INT`.

--- a/goup.go
+++ b/goup.go
@@ -39,7 +39,6 @@ type project struct {
 }
 
 func main() {
-	panic(os.Getenv("GOUP_TERM_SIGNAL"))
 	prj, err := read()
 	if err != nil {
 		logger.Fatalf("failed import: %v", err)

--- a/goup.go
+++ b/goup.go
@@ -39,6 +39,7 @@ type project struct {
 }
 
 func main() {
+	panic(os.Getenv("GOUP_TERM_SIGNAL"))
 	prj, err := read()
 	if err != nil {
 		logger.Fatalf("failed import: %v", err)


### PR DESCRIPTION
This PR adds the ability to switch the termination signal to `SIGINT` or `SIGTERM` by setting the `GOUP_TERM_SIGNAL` env var. The previous default behavior of the program of using `SIGTERM` is preserved if the user does not configure anything.